### PR TITLE
Add function to get size of a Texture

### DIFF
--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -47,6 +47,12 @@ Elm.Native.WebGL.make = function(elm) {
 
   }
 
+  function textureSize(texture) {
+
+    return Tuple2(texture.img.width, texture.img.height);
+
+  }
+
   function entity(vert, frag, buffer, uniforms) {
 
     if (!buffer.guid) {
@@ -445,6 +451,7 @@ Elm.Native.WebGL.make = function(elm) {
   return elm.Native.WebGL.values = {
     unsafeCoerceGLSL:unsafeCoerceGLSL,
     loadTex:loadTex,
+    textureSize:textureSize,
     entity:F4(entity),
     webgl:F2(webgl)
   };

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -15,7 +15,7 @@ documentation provided here.
 @docs webgl
 
 # Loading Textures
-@docs loadTexture
+@docs loadTexture, textureSize
 
 # Unsafe Shader Creation (for library writers)
 @docs unsafeShader

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -88,7 +88,15 @@ loadTexture =
   Native.WebGL.loadTex
 
 
-type Entity = Entity 
+{-| Return the (width, height) size of a texture. Useful for sprite sheets
+or other times you may want to use only a potion of a texture image.
+-}
+textureSize : Texture -> (Int, Int)
+textureSize =
+    Native.WebGL.textureSize
+
+
+type Entity = Entity
 
 
 {-| Packages a vertex shader, a fragment shader, a mesh, and uniform variables


### PR DESCRIPTION
I want a function to get the size of a texture so I can implement shaders to do general sprite sheets. Right now I have to hard code in the expected dimensions of the texture or require the user to specify, but that's not really ideal.