### PR TITLE
Update for 0.15

### DIFF
--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -14,37 +14,41 @@ Elm.Native.WebGL.make = function(elm) {
   }
 
   var createNode = Elm.Native.Graphics.Element.make(elm).createNode;
-  var newElement = Elm.Graphics.Element.make(elm).newElement;
+  var newElement = Elm.Native.Graphics.Element.make(elm).newElement;
 
-  var List = Elm.Native.List.make(elm);
-  var Utils = Elm.Native.Utils.make(elm);
+  var List   = Elm.List.make(elm);
+  var Utils  = Elm.Native.Utils.make(elm);
   var Signal = Elm.Signal.make(elm);
   var Tuple2 = Utils.Tuple2;
+  var Task   = Elm.Native.Task.make(elm);
 
   function unsafeCoerceGLSL(src) {
     return { src : src };
   }
 
-  function loadTex(source) {
+  function toTexture(req) {
+    var img  = new Image();
+    img.src = URL.createObjectURL(req.response);
+    return {img:img};
+  };
 
-    var response = Signal.constant(elm.Http.values.Waiting);
-
-    var img = new Image();
-
-    img.onload = function() {
-      var success = elm.Http.values.Success({img:img});
-      elm.notify(response.id, success);
-    }
-
-    img.onerror = function(e) {
-      var failure = A2(elm.Http.values.Failure,0,"Failed");
-      elm.notify(response.id, failure);
-    }
-
-    img.src = source;
-
-    return response;
-
+  function loadTexture(url) {
+    return Task.asyncFunction(function(callback) {
+      var req = new XMLHttpRequest;
+      req.addEventListener('error', function() {
+        return callback(Task.fail({ ctor: 'NetworkError' }));
+      });
+      req.addEventListener('timeout', function() {
+        return callback(Task.fail({ ctor: 'Timeout' }));
+      });
+      req.addEventListener('load', function() {
+        return callback(Task.succeed(toTexture(req)));
+      });
+      req.open('get', url, true);
+      req.timeout = 30;
+      req.responseType = 'blob';
+      req.send();
+    });
   }
 
   function entity(vert, frag, buffer, uniforms) {
@@ -209,7 +213,10 @@ Elm.Native.WebGL.make = function(elm) {
     }
 
     var numIndices = 3 * List.length(bufferElems);
-    var indices = List.toArray(List.range(0, numIndices - 1));
+    var indices = [];
+    for (var i = 0; i < numIndices; i += 1) {
+      indices.push(i);
+    }
     LOG("Created index buffer");
     var indexBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
@@ -231,6 +238,7 @@ Elm.Native.WebGL.make = function(elm) {
 
     gl.viewport(0, 0, model.w, model.h);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
     LOG("Drawing");
 
     function drawEntity(entity) {
@@ -444,7 +452,7 @@ Elm.Native.WebGL.make = function(elm) {
 
   return elm.Native.WebGL.values = {
     unsafeCoerceGLSL:unsafeCoerceGLSL,
-    loadTex:loadTex,
+    loadTexture:loadTexture,
     entity:F4(entity),
     webgl:F2(webgl)
   };

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -79,17 +79,16 @@ unsafeShader =
 
 type Texture = Texture
 
+type Error =
+    NetworkError
+  | Timeout
 
 {-| Loads a texture from the given url. PNG and JPEG are known to work, but
 other formats have not been as well-tested yet.
 -}
-loadTexture : String -> Task RawError Texture
-loadTexture url = 
-  let request = { verb = "GET", headers = [], url = url, body = empty }
-  in send defaultSettings request `andThen` decodeTexture
-
-decodeTexture : Response -> Task RawError Texture
-decodeTexture = Native.WebGL.decodeTexture
+loadTexture : String -> Task Error Texture
+loadTexture url =
+  Native.WebGL.loadTexture url
 
 type Entity = Entity 
 


### PR DESCRIPTION
I managed to get support for Elm 0.15 working.

Changes have been tested with Mozilla Firefox 32.0 and a custom server for png textures.

I plan on testing with Chrome, file:/// images, elm-reactor, other file types, and update the examples.