### PR TITLE
Really update for 0.15

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "A library for general 3D rendering with WebGL",
     "repository": "https://github.com/johnpmayer/elm-webgl.git",
     "license": "BSD3",
@@ -12,7 +12,6 @@
     "native-modules": true,
     "dependencies": {
         "elm-lang/core": "2.0.0 <= v < 3.0.0",
-        "evancz/elm-http": "1.0.0 <= v < 2.0.0",
         "johnpmayer/elm-linear-algebra": "2.0.1 <= v < 3.0.0"
     },
     "elm-version": "0.15.0 <= v < 0.16.0"

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -14,37 +14,29 @@ Elm.Native.WebGL.make = function(elm) {
   }
 
   var createNode = Elm.Native.Graphics.Element.make(elm).createNode;
-  var newElement = Elm.Graphics.Element.make(elm).newElement;
+  var newElement = Elm.Native.Graphics.Element.make(elm).newElement;
 
-  var List = Elm.Native.List.make(elm);
-  var Utils = Elm.Native.Utils.make(elm);
+  var List   = Elm.List.make(elm);
+  var Utils  = Elm.Native.Utils.make(elm);
   var Signal = Elm.Signal.make(elm);
   var Tuple2 = Utils.Tuple2;
+  var Task   = Elm.Native.Task.make(elm);
 
   function unsafeCoerceGLSL(src) {
     return { src : src };
   }
 
-  function loadTex(source) {
-
-    var response = Signal.constant(elm.Http.values.Waiting);
-
-    var img = new Image();
-
-    img.onload = function() {
-      var success = elm.Http.values.Success({img:img});
-      elm.notify(response.id, success);
-    }
-
-    img.onerror = function(e) {
-      var failure = A2(elm.Http.values.Failure,0,"Failed");
-      elm.notify(response.id, failure);
-    }
-
-    img.src = source;
-
-    return response;
-
+  function loadTexture(source) {
+    return Task.asyncFunction(function(callback) {
+      var img = new Image();
+      img.onload = function() {
+        return callback(Task.succeed({img:img}));
+      };
+      img.onerror = function(e) {
+        return callback(Task.fail({ ctor: 'Error' }));
+      };
+      img.src = source;
+    });
   }
 
   function entity(vert, frag, buffer, uniforms) {
@@ -209,7 +201,10 @@ Elm.Native.WebGL.make = function(elm) {
     }
 
     var numIndices = 3 * List.length(bufferElems);
-    var indices = List.toArray(List.range(0, numIndices - 1));
+    var indices = [];
+    for (var i = 0; i < numIndices; i += 1) {
+      indices.push(i);
+    }
     LOG("Created index buffer");
     var indexBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
@@ -444,7 +439,7 @@ Elm.Native.WebGL.make = function(elm) {
 
   return elm.Native.WebGL.values = {
     unsafeCoerceGLSL:unsafeCoerceGLSL,
-    loadTex:loadTex,
+    loadTexture:loadTexture,
     entity:F4(entity),
     webgl:F2(webgl)
   };

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -23,10 +23,8 @@ documentation provided here.
 -}
 
 import Graphics.Element exposing (Element)
-import Http exposing (defaultSettings, empty, RawError, Response, send)
 import Native.WebGL
-import Signal exposing (Mailbox)
-import Task exposing (andThen, Task)
+import Task exposing (Task)
 
 {-| Triangles are the basic building blocks of a mesh. You can put them together
 to form any shape. Each corner of a triangle is called a *vertex* and contains a
@@ -79,17 +77,15 @@ unsafeShader =
 
 type Texture = Texture
 
+type Error =
+    Error
 
 {-| Loads a texture from the given url. PNG and JPEG are known to work, but
 other formats have not been as well-tested yet.
 -}
-loadTexture : String -> Task RawError Texture
-loadTexture url = 
-  let request = { verb = "GET", headers = [], url = url, body = empty }
-  in send defaultSettings request `andThen` decodeTexture
-
-decodeTexture : Response -> Task RawError Texture
-decodeTexture = Native.WebGL.decodeTexture
+loadTexture : String -> Task Error Texture
+loadTexture url =
+  Native.WebGL.loadTexture url
 
 type Entity = Entity 
 

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -79,16 +79,17 @@ unsafeShader =
 
 type Texture = Texture
 
-type Error =
-    NetworkError
-  | Timeout
 
 {-| Loads a texture from the given url. PNG and JPEG are known to work, but
 other formats have not been as well-tested yet.
 -}
-loadTexture : String -> Task Error Texture
-loadTexture url =
-  Native.WebGL.loadTexture url
+loadTexture : String -> Task RawError Texture
+loadTexture url = 
+  let request = { verb = "GET", headers = [], url = url, body = empty }
+  in send defaultSettings request `andThen` decodeTexture
+
+decodeTexture : Response -> Task RawError Texture
+decodeTexture = Native.WebGL.decodeTexture
 
 type Entity = Entity 
 


### PR DESCRIPTION
Further testing revealed that changes were not compatible with Chrome. I reverted changes back to the previous version. This seems to be more robust, as examples are now working in both Firefox and Chrome.

Apologies for the faulty PR!

Examples are updated in aforemny/elm-lang.org@1756758.