### PR TITLE
Default texture filters to GL_NEAREST

### DIFF
--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -10,7 +10,7 @@ Elm.Native.WebGL.make = function(elm) {
 
   // setup logging
   function LOG(msg) {
-    // console.log(msg);
+    console.log(msg);
   }
 
   var createNode = Elm.Native.Graphics.Element.make(elm).createNode;
@@ -30,7 +30,20 @@ Elm.Native.WebGL.make = function(elm) {
     return Task.asyncFunction(function(callback) {
       var img = new Image();
       img.onload = function() {
-        return callback(Task.succeed({img:img}));
+        return callback(Task.succeed({ctor:'Texture', img:img}));
+      };
+      img.onerror = function(e) {
+        return callback(Task.fail({ ctor: 'Error' }));
+      };
+      img.src = source;
+    });
+  }
+
+  function loadTextureRaw(source) {
+    return Task.asyncFunction(function(callback) {
+      var img = new Image();
+      img.onload = function() {
+        return callback(Task.succeed({ctor:'RawTexture', img:img}));
       };
       img.onerror = function(e) {
         return callback(Task.fail({ ctor: 'Error' }));
@@ -54,15 +67,23 @@ Elm.Native.WebGL.make = function(elm) {
 
   }
 
-  function do_texture (gl, img) {
+  function do_texture (gl, texture) {
 
     var tex = gl.createTexture();
     LOG("Created texture");
     gl.bindTexture(gl.TEXTURE_2D, tex);
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, texture.img);
+    switch (texture.ctor) {
+      case 'Texture':
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+        break;
+      case 'RawTexture':
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        break;
+    };
     gl.generateMipmap(gl.TEXTURE_2D);
     //gl.bindTexture(gl.TEXTURE0, null);
     return tex;
@@ -303,7 +324,7 @@ Elm.Native.WebGL.make = function(elm) {
               texture.id = Utils.guid();
             }
             if (!tex) {
-              tex = do_texture(gl, texture.img);
+              tex = do_texture(gl, texture);
               model.cache.textures[texture.id] = tex;
             }
             var activeName = 'TEXTURE' + textureCounter;
@@ -440,6 +461,7 @@ Elm.Native.WebGL.make = function(elm) {
   return elm.Native.WebGL.values = {
     unsafeCoerceGLSL:unsafeCoerceGLSL,
     loadTexture:loadTexture,
+    loadTextureRaw:loadTextureRaw,
     entity:F4(entity),
     webgl:F2(webgl)
   };

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -10,7 +10,7 @@ Elm.Native.WebGL.make = function(elm) {
 
   // setup logging
   function LOG(msg) {
-    console.log(msg);
+    // console.log(msg);
   }
 
   var createNode = Elm.Native.Graphics.Element.make(elm).createNode;

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -61,8 +61,8 @@ Elm.Native.WebGL.make = function(elm) {
     gl.bindTexture(gl.TEXTURE_2D, tex);
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
     gl.generateMipmap(gl.TEXTURE_2D);
     //gl.bindTexture(gl.TEXTURE0, null);
     return tex;

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -15,7 +15,7 @@ documentation provided here.
 @docs webgl
 
 # Loading Textures
-@docs loadTexture
+@docs loadTexture, loadTextureRaw
 
 # Unsafe Shader Creation (for library writers)
 @docs unsafeShader
@@ -75,7 +75,12 @@ unsafeShader =
   Native.WebGL.unsafeCoerceGLSL
 
 
-type Texture = Texture
+{-| A `Texture` loads a texture with linear filtering enabled. If you do not
+want filtering, create a `RawTexture` with `loadTextureRaw`.
+-}
+type Texture =
+    RawTexture
+  | Texture
 
 type Error =
     Error
@@ -86,6 +91,10 @@ other formats have not been as well-tested yet.
 loadTexture : String -> Task Error Texture
 loadTexture url =
   Native.WebGL.loadTexture url
+
+loadTextureRaw : String -> Task Error Texture
+loadTextureRaw url =
+  Native.WebGL.loadTextureRaw url
 
 type Entity = Entity 
 


### PR DESCRIPTION
I would like to argue that the default min/mag filters should be changed from ```GL_LINEAR``` to ```GL_NEAREST```.

The motivation is that ```GL_NEAREST``` is more flexible: For textures it gives you a pixelated look. Something which is not possible with ```GL_LINEAR``` filters. If you want filtering you should write it yourself in your fragment shader by evaluating your color function for ```n``` pixels with offsets ```delta_1…delta_n```, and then average them for the fragment color.

Also, if you treat your textures as height maps you would want to get the accurate height information of that pixel, and not some average of pixels as it is the case with ```GL_LINEAR```.

Is this convincing?

Would an example be appreciated that shows how to do filtering with the default being no filtering?