### PR TITLE
Added different draw mode functionality, also support for FLOAT types as attributes.

### DIFF
--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -153,32 +153,30 @@ Elm.Native.WebGL.make = function(elm) {
 	  }
 	  
 	  var data_idx = 0; 
-	  var array = new attributeInfo.type( List.length(bufferElems) * attributeInfo.size );
+	  var array = new attributeInfo.type( List.length(bufferElems) * attributeInfo.size * elem_length);
 	  	  
 	  A2(List.map, function(elem) {
 		dataFill(array, attributeInfo.size, data_idx, elem, attribute.name); 
-		data_idx += attributeInfo.size;
+		data_idx += attributeInfo.size * elem_length;
 	  }, bufferElems);
 	  
-
 	  var buffer = gl.createBuffer();
 	  LOG("Created attribute buffer " + attribute.name);
 	  gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
 	  gl.bufferData(gl.ARRAY_BUFFER, array, gl.STATIC_DRAW);
-
+      buffer.length = List.length(bufferElems) * attributeInfo.size * elem_length; 
 	  buffers[attribute.name] = buffer;
-
     }
 
     var numIndices = elem_length * List.length(bufferElems);
-    var indices = [];
+    var indices = new Uint16Array(numIndices);
     for (var i = 0; i < numIndices; i += 1) {
-      indices.push(i);
+      indices[i] = i; 
     }
     LOG("Created index buffer");
     var indexBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
-    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(indices), gl.STATIC_DRAW);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
 
     var bufferObject = {
       numIndices: numIndices,
@@ -309,7 +307,6 @@ Elm.Native.WebGL.make = function(elm) {
 		gl.bindBuffer(gl.ARRAY_BUFFER, attributeBuffer);
 		gl.vertexAttribPointer(attribLocation, attributeInfo.size, attributeInfo.baseType, false, 0, 0);
       }
-
       gl.drawElements(entityType.mode, numIndices, gl.UNSIGNED_SHORT, 0);
 
     }

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -26,33 +26,29 @@ import Graphics.Element exposing (Element)
 import Native.WebGL
 import Task exposing (Task)
 
-{-| Triangles are the basic building blocks of a mesh. You can put them together
+{-| 
+WebGl has a number of rendering modes available. Each of the tagged union types 
+maps to a separate rendering mode. 
+
+Triangles are the basic building blocks of a mesh. You can put them together
 to form any shape. Each corner of a triangle is called a *vertex* and contains a
 bunch of *attributes* that describe that particular corner. These attributes can
 be things like position and color.
 
 So when you create a `Triangle` you are really providing three sets of attributes
 that describe the corners of a triangle.
+
+See: [Library reference](https://msdn.microsoft.com/en-us/library/dn302395(v=vs.85).aspx) for the description of each type. 
 -}
-type alias Triangle attributes =
-    (attributes, attributes, attributes)
 
-
-{-| Apply a function to each vertex. This lets you transform the set of
-attributes associated with each corner of a triangle.
--}
-map : (a -> b) -> Triangle a -> Triangle b
-map f (x,y,z) =
-    (f x, f y, f z)
-
-
-{-| Combine two triangles by putting each of their vertices together with
-a given function.
--}
-map2 : (a -> b -> c) -> Triangle a -> Triangle b -> Triangle c
-map2 f (x,y,z) (x',y',z') =
-    (f x x', f y y', f z z')
-
+type RenderableType attributes
+  = Triangle (List (attributes, attributes, attributes))
+  | Lines (List (attributes, attributes) )
+  | LineStrip (List attributes)
+  | LineLoop (List attributes)
+  | Points (List attributes)
+  | TriangleFan (List attributes)
+  | TriangleStrip (List attributes)
 
 {-| Shader is a phantom data type. Don't instantiate it yourself. See below.
 -}
@@ -99,7 +95,7 @@ Values will be cached intelligently, so if you have already sent a shader or
 mesh to the GPU, it will not be resent. This means it is fairly cheap to create
 new entities if you are reusing shaders and meshes that have been used before.
 -}
-entity : Shader attributes uniforms varyings -> Shader {} uniforms varyings -> List (Triangle attributes) -> uniforms -> Entity
+entity : Shader attributes uniforms varyings -> Shader {} uniforms varyings -> (RenderableType attributes) -> uniforms -> Entity
 entity =
   Native.WebGL.entity
 


### PR DESCRIPTION
Apologies to @rhaps0dy, I didn't check the existing pull requests before I wrote this. 

This would be the other way to implement the same functionality though, with the major difference that it does break API compatibility from previous versions. Even so, I think this is more idiomatic for functional languages as it uses a tagged union to distinguish between the rendering modes. Every supported WebGL rendering mode is supported here. 

I'm rusty at haskell and this is the first thing I have done in Elm so it might have some oddities. The main thing I was on the fence about was representing things like *_strip, where not all sized lists are valid, but that constraint isn't represented in the type at all. It could be by making it a record, but this would make the construction of those types ugly. 

Another useful addition in this patch is that it includes support for FLOAT attributes, and would be easy to extend to include the int/bool types as well. 

[Here is a gist for a demo of the functionality](https://gist.github.com/jdavidberger/32531d2e041a6bc393c3)

I did not bump the versioning in the package, for this, although I think it would bump it to v4. 