### PR TITLE
Bringing support for all pre-fragment operations and some special fun...

### DIFF
--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -284,7 +284,7 @@ Elm.Native.WebGL.make = function(elm) {
             break;
           case gl.FLOAT_VEC2:
             gl.uniform2fv(uniformLocation, entity.uniforms[uniform.name]);
-            break;            
+            break;
           case gl.FLOAT_VEC3:
             gl.uniform3fv(uniformLocation, entity.uniforms[uniform.name]);
             break;
@@ -362,7 +362,67 @@ Elm.Native.WebGL.make = function(elm) {
 
   }
 
-  function webgl(dimensions, models) {
+  function enable(capability) {
+    return function(gl) { gl.enable(gl[capability]); };
+  }
+
+  function disable(capability) {
+    return function(gl) { gl.disable(gl[capability]); };
+  }
+
+  function blendColor(r, g, b, a) {
+    return function(gl) { gl.blendColor(r, g, b, a); };
+  }
+
+  function blendEquation(mode) {
+    return function(gl) { gl.blendEquation(gl[mode]); };
+  }
+
+  function blendEquationSeparate(modeRGB, modeAlpha) {
+    return function(gl) {
+      gl.blendEquationSeparate(gl[modeRGB], gl[modeAlpha]);
+    };
+  }
+
+  function blendFunc(src, dst) {
+    return function(gl) { gl.blendFunc(gl[src], gl[dst]); };
+  }
+
+  function depthFunc(mode) {
+    return function(gl) { gl.depthFunc(gl[mode]); };
+  }
+
+  function sampleCoverage(value, invert) {
+    return function(gl) {
+      gl.sampleCoverage(value, invert);
+    };
+  }
+
+  function stencilFunc(func, ref, mask) {
+    return function(gl) {
+      gl.stencilFunc(gl[func], ref, mask);
+    };
+  }
+
+  function stencilFuncSeparate(face, func, ref, mask) {
+    return function(gl) {
+      gl.stencilFuncSeparate(gl[face], gl[func], ref, mask);
+    };
+  }
+
+  function stencilOperation(fail, zfail, zpass) {
+    return function(gl) {
+      gl.stencilOperation(gl[fail], gl[zfail], gl[zpass]);
+    }
+  }
+
+  function stencilOperationSeparate(face, fail, zfail, zpass) {
+    return function(gl) {
+      gl.stencilOperationSeparate(gl[face], gl[fail], gl[zfail], gl[zpass]);
+    }
+  }
+
+  function webgl(dimensions, models, functionCalls) {
 
     var w = dimensions._0;
     var h = dimensions._1;
@@ -375,7 +435,9 @@ Elm.Native.WebGL.make = function(elm) {
       var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
 
       if (gl) {
-        gl.enable(gl.DEPTH_TEST);
+        A2(List.map, function(functionCall){
+          functionCall(gl);
+        }, functionCalls);
       } else {
         div.innerHTML =
           '<div style="display: table-cell; text-align: center; width: ' + w + 'px; height: ' + h +
@@ -441,7 +503,19 @@ Elm.Native.WebGL.make = function(elm) {
     unsafeCoerceGLSL:unsafeCoerceGLSL,
     loadTexture:loadTexture,
     entity:F4(entity),
-    webgl:F2(webgl)
+    webgl:F3(webgl),
+    enable:enable,
+    disable:disable,
+    blendColor:F4(blendColor),
+    blendEquation:blendEquation,
+    blendEquationSeparate:F2(blendEquationSeparate),
+    blendFunc:F2(blendFunc),
+    depthFunc:depthFunc,
+    sampleCoverage:F2(sampleCoverage),
+    stencilFunc:F3(stencilFunc),
+    stencilFuncSeparate:F4(stencilFuncSeparate),
+    stencilOperation:F3(stencilOperation),
+    stencilOperationSeparate:F4(stencilOperationSeparate),
   };
 
 };

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -39,7 +39,7 @@ Elm.Native.WebGL.make = function(elm) {
     });
   }
 
-  function entity(vert, frag, buffer, uniforms) {
+  function entity(vert, frag, buffer, uniforms, functionCalls) {
 
     if (!buffer.guid) {
       buffer.guid = Utils.guid();
@@ -49,7 +49,8 @@ Elm.Native.WebGL.make = function(elm) {
       vert: vert,
       frag: frag,
       buffer: buffer,
-      uniforms: uniforms
+      uniforms: uniforms,
+      functionCalls : functionCalls
     };
 
   }
@@ -354,6 +355,10 @@ Elm.Native.WebGL.make = function(elm) {
         }
       }
 
+      A2(List.map, function(functionCall){
+        functionCall(gl);
+      }, entity.functionCalls);
+
       gl.drawElements(gl.TRIANGLES, numIndices, gl.UNSIGNED_SHORT, 0);
 
     }
@@ -502,7 +507,7 @@ Elm.Native.WebGL.make = function(elm) {
   return elm.Native.WebGL.values = {
     unsafeCoerceGLSL:unsafeCoerceGLSL,
     loadTexture:loadTexture,
-    entity:F4(entity),
+    entity:F5(entity),
     webgl:F3(webgl),
     enable:enable,
     disable:disable,

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -9,10 +9,10 @@ documentation provided here.
 @docs Triangle, map, map2
 
 # Entities
-@docs entity
+@docs entity, entityWithConfig
 
 # WebGL Element
-@docs webgl
+@docs webgl, webglWithConfig, defaultConfiguration
 
 # WebGL API Calls
 @docs FunctionCall
@@ -105,17 +105,42 @@ Values will be cached intelligently, so if you have already sent a shader or
 mesh to the GPU, it will not be resent. This means it is fairly cheap to create
 new entities if you are reusing shaders and meshes that have been used before.
 -}
+entityWithConfig : List FunctionCall -> Shader attributes uniforms varyings -> Shader {} uniforms varyings -> List (Triangle attributes) -> uniforms -> Entity
+entityWithConfig functionCalls vert frag buffer uniforms =
+  computeAPICalls functionCalls
+  |> Native.WebGL.entity vert frag buffer uniforms
+
+
+{-| Same as `entityWithConfig` but without using
+custom per-entity configurations.
+-}
 entity : Shader attributes uniforms varyings -> Shader {} uniforms varyings -> List (Triangle attributes) -> uniforms -> Entity
-entity =
-  Native.WebGL.entity
+entity = entityWithConfig []
+
+
+{-| Default configuration that is used as
+the implicit configurations for `webgl`.
+-}
+defaultConfiguration : List FunctionCall
+defaultConfiguration =
+  [ Enable DepthTest
+  ]
+
+
+{-| Same as webglWithConfig but with default configurations,
+implicitly configured for you. See `defaultConfiguration` for more information.
+-}
+webgl : (Int,Int) -> List Entity -> Element
+webgl =
+  webglWithConfig defaultConfiguration
 
 
 {-| Render a WebGL scene with the given dimensions and entities. Shaders and
 meshes are cached so that they do not get resent to the GPU, so it should be
 relatively cheap to create new entities out of existing values.
 -}
-webgl : (Int,Int) -> List FunctionCall -> List Entity -> Element
-webgl dimensions functionCalls entities =
+webglWithConfig : List FunctionCall -> (Int,Int) -> List Entity -> Element
+webglWithConfig functionCalls dimensions entities =
   computeAPICalls functionCalls
   |> Native.WebGL.webgl dimensions entities
 

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -14,6 +14,12 @@ documentation provided here.
 # WebGL Element
 @docs webgl
 
+# WebGL API Calls
+@docs FunctionCall
+
+# WebGL API Types
+@docs Capability, BlendOperation, BlendMode, CompareMode, FaceMode, ZMode
+
 # Loading Textures
 @docs loadTexture
 
@@ -87,7 +93,7 @@ loadTexture : String -> Task Error Texture
 loadTexture url =
   Native.WebGL.loadTexture url
 
-type Entity = Entity 
+type Entity = Entity
 
 
 {-| Packages a vertex shader, a fragment shader, a mesh, and uniform variables
@@ -108,6 +114,427 @@ entity =
 meshes are cached so that they do not get resent to the GPU, so it should be
 relatively cheap to create new entities out of existing values.
 -}
-webgl : (Int,Int) -> List Entity -> Element
-webgl =
-  Native.WebGL.webgl
+webgl : (Int,Int) -> List FunctionCall -> List Entity -> Element
+webgl dimensions functionCalls entities =
+  computeAPICalls functionCalls
+  |> Native.WebGL.webgl dimensions entities
+
+
+computeAPICalls : List FunctionCall -> List (a -> b)
+computeAPICalls functionCalls =
+  List.map
+    computeAPICall
+    functionCalls
+
+
+computeAPICall : FunctionCall -> (a -> b)
+computeAPICall function =
+  case function of
+    Enable capability ->
+      computeCapabilityString capability
+      |> Native.WebGL.enable
+
+    Disable capability ->
+      computeCapabilityString capability
+      |> Native.WebGL.disable
+
+    BlendColor (r, g, b, a) ->
+      Native.WebGL.blendColor r g b a
+
+    BlendEquation mode ->
+      computeBlendModeString mode
+      |> Native.WebGL.blendEquation
+
+    BlendEquationSeparate (modeRGB', modeAlpha') ->
+      let modeRGB = computeBlendModeString modeRGB'
+          modeAlpha = computeBlendModeString modeAlpha'
+      in Native.WebGL.blendEquationSeparate modeRGB modeAlpha
+
+    BlendFunc (src', dst') ->
+      let src = computeBlendOperationString src'
+          dst = computeBlendOperationString dst'
+      in Native.WebGL.blendFunc src dst
+
+    DepthFunc mode ->
+      computeCompareModeString mode
+      |> Native.WebGL.depthFunc
+
+    SampleCoverageFunc (value, invert) ->
+      Native.WebGL.sampleCoverage value invert
+
+    StencilFunc (func, ref, mask) ->
+      let mode = computeCompareModeString func
+      in Native.WebGL.stencilFunc mode ref mask
+
+    StencilFuncSeparate (face', func, ref, mask) ->
+      let face = computeFaceModeString face'
+          mode = computeCompareModeString func
+      in Native.WebGL.stencilFuncSeparate face mode ref mask
+
+    StencilOperation (fail', zfail', zpass') ->
+      let fail = computeZModeString fail'
+          zfail = computeZModeString zfail'
+          zpass = computeZModeString zpass'
+      in Native.WebGL.stencilOperation fail zfail zpass
+
+    StencilOperationSeparate (face', fail', zfail', zpass') ->
+      let face = computeFaceModeString face'
+          fail = computeZModeString fail'
+          zfail = computeZModeString zfail'
+          zpass = computeZModeString zpass'
+      in Native.WebGL.stencilOperationSeparate face fail zfail zpass
+
+
+{-| The `FunctionCall` provides a typesafe way to call
+all pre-fragment operations and some special functions.
+
+`Enable(capability: Capability)`
++ enable server-side GL capabilities
+
+`Disable(cap: Capability)`
++ disable server-side GL capabilities
+
+`BlendColor(red: Float, green: Float, blue: Float, alpha: Float)`
++ set the blend color
+
+`BlendEquation(mode: BlendMode)`
++ specify the equation used for both the
+RGB blend equation and the Alpha blend equation
++ `mode`: specifies how source and destination colors are combined
+
+`BlendEquationSeparate(modeRGB: BlendMode, modeAlpha: BlendMode)`
++ set the RGB blend equation and the alpha blend equation separately
++ `modeRGB`: specifies the RGB blend equation, how the red, green,
+and blue components of the source and destination colors are combined
++ `modeAlpha`: specifies the alpha blend equation, how the alpha component
+of the source and destination colors are combined
+
+`BlendFunc(srcFactor: BlendMode, dstFactor: BlendMode)`
++ specify pixel arithmetic
++ `srcFactor`: Specifies how the red, green, blue,
+and alpha source blending factors are computed
++ `dstFactor`: Specifies how the red, green, blue,
+and alpha destination blending factors are computed
++ `SrcAlphaSaturate` should only be used for the srcFactor);
++ Both values may not reference a `ConstantColor` value;
+
+`SampleCoverageFunc(value: Float, invert: Bool)`
++ specify multisample coverage parameters
++ `value`: Specify a single floating-point sample coverage value.
+The value is clamped to the range 0 1 . The initial value is `1`
++ `invert`: Specify a single boolean value representing
+if the coverage masks should be inverted. The initial value is `False`
+
+`StencilFunc(func: CompareMode, ref: Int, mask: Int)`
++ set front and back function and reference value for stencil testing
++ `func`: Specifies the test function.  The initial value is `Always`
++ `ref`: Specifies the reference value for the stencil test. ref is
+clamped to the range 0 2 n - 1 , where n is the number of bitplanes
+in the stencil buffer. The initial value is `0`.
++ `mask`: Specifies a mask that is ANDed with both the reference value
+and the stored stencil value when the test is done.
+The initial value is all `1`'s.
+
+`StencilFuncSeparate(face: FaceMode, func: CompareMode, ref: Int, mask: Int)`
++ set front and/or back function and reference value for stencil testing
++ `face`: Specifies whether front and/or back stencil state is updated
++ see the description of `StencilFunc` for info about the other parameters
+
+`StencilOperation(fail: ZMode, zfail: ZMode, pass: ZMode)`
++ set front and back stencil test actions
++ `fail`: Specifies the action to take when the stencil test fails.
+The initial value is `Keep`
++ `zfail`: Specifies the stencil action when the stencil test passes,
+but the depth test fails. The initial value is `Keep`
++ `pass`: Specifies the stencil action when both the stencil test
+and the depth test pass, or when the stencil test passes and either
+there is no depth buffer or depth testing is not enabled.
+The initial value is `Keep`
+
+`StencilOperationSeparate(face: FaceMode, fail: ZMode, zfail: ZMode, pass: Zmode)`
++ set front and/or back stencil test actions
++ `face`: Specifies whether front and/or back stencil state is updated.
++ See the description of `StencilOperation` for info about the other parameters.
+-}
+type FunctionCall
+  = Enable Capability
+  | Disable Capability
+  | BlendColor (Float, Float, Float, Float)
+  | BlendEquation BlendMode
+  | BlendEquationSeparate (BlendMode, BlendMode)
+  | BlendFunc (BlendOperation, BlendOperation)
+  | DepthFunc CompareMode
+  | SampleCoverageFunc (Float, Bool)
+  | StencilFunc (CompareMode, Int, Int)
+  | StencilFuncSeparate (FaceMode, CompareMode, Int, Int)
+  | StencilOperation (ZMode, ZMode, ZMode)
+  | StencilOperationSeparate (FaceMode, ZMode, ZMode, ZMode)
+
+
+computeCapabilityString : Capability -> String
+computeCapabilityString capability =
+  case capability of
+    Blend ->
+      "BLEND"
+
+    CullFace ->
+      "CULL_FACE"
+
+    DepthTest ->
+      "DEPTH_TEST"
+
+    Dither ->
+      "DITHER"
+
+    PolygonOffsetFill ->
+      "POLYGON_OFFSET_FILL"
+
+    SampleAlphaToCoverage ->
+      "SAMPLE_ALPHA_TO_COVERAGE"
+
+    SampleCoverage ->
+      "SAMPLE_COVERAGE"
+
+    ScissorTest ->
+      "SCISSOR_TEST"
+
+    StencilTest ->
+      "STENCIL_TEST"
+
+
+{-| The `Capability` type is used to enable/disable server-side GL capabilities.
+
++ `Blend`: If enabled, blend the computed fragment color values
+with the values in the color buffers.
++ `CullFace`: If enabled, cull polygons based on their winding in window coordinates.
++ `DepthTest`: If enabled, do depth comparisons and update the depth buffer.
++ `Dither`: If enabled, dither color components.
+or indices before they are written to the color buffer.
++ `PolygonOffsetFill`: If enabled, an offset is added
+to depth values of a polygon's fragments produced by rasterization.
++ `SampleAlphaToCoverage`: If enabled, compute a temporary coverage value
+where each bit is determined by the alpha value at the corresponding sample location.
+The temporary coverage value is then ANDed with the fragment coverage value.
++ `SampleCoverage`: If enabled, the fragment's coverage
+is ANDed with the temporary coverage value.
++ `ScissorTest`: If enabled, discard fragments that are outside the scissor rectangle
++ `StencilTest`: If enabled, do stencil testing and update the stencil buffer.
+-}
+type Capability
+  = Blend
+  | CullFace
+  | DepthTest
+  | Dither
+  | PolygonOffsetFill
+  | SampleAlphaToCoverage
+  | SampleCoverage
+  | ScissorTest
+  | StencilTest
+
+
+computeBlendOperationString : BlendOperation -> String
+computeBlendOperationString operation =
+  case operation of
+    Zero ->
+      "ZERO"
+
+    One ->
+      "ONE"
+
+    SrcColor ->
+      "SRC_COLOR"
+
+    OneMinusSrcColor ->
+      "ONE_MINUS_SRC_COLOR"
+
+    DstColor ->
+      "DST_COLOR"
+
+    OneMinusDstColor ->
+      "ONE_MINUS_DST_COLOR"
+
+    SrcAlpha ->
+      "SRC_ALPHA"
+
+    OneMinusSrcAlpha ->
+      "ONE_MINUS_SRC_ALPHA"
+
+    DstAlpha ->
+      "DST_ALPHA"
+
+    OneMinusDstAlpha ->
+      "ONE_MINUS_DST_ALPHA"
+
+    ConstantColor ->
+      "CONSTANT_COLOR"
+
+    OneMinusConstantColor ->
+      "ONE_MINUS_CONSTANT_COLOR"
+
+    ConstantAlpha ->
+      "CONSTANT_ALPHA"
+
+    OneMinusConstantAlpha ->
+      "ONE_MINUS_CONSTANT_ALPHA"
+
+    SrcAlphaSaturate ->
+      "SRC_ALPHA_SATURATE"
+
+
+{-| The `BlendOperation` type allows you to define which blend operation to use.
+-}
+type BlendOperation
+  = Zero
+  | One
+  | SrcColor
+  | OneMinusSrcColor
+  | DstColor
+  | OneMinusDstColor
+  | SrcAlpha
+  | OneMinusSrcAlpha
+  | DstAlpha
+  | OneMinusDstAlpha
+  | ConstantColor
+  | OneMinusConstantColor
+  | ConstantAlpha
+  | OneMinusConstantAlpha
+  | SrcAlphaSaturate
+
+
+computeBlendModeString : BlendMode -> String
+computeBlendModeString mode =
+  case mode of
+    Add ->
+      "FUNC_ADD"
+
+    Subtract ->
+      "FUNC_SUBTRACT"
+
+    ReverseSubtract ->
+      "FUNC_REVERSE_SUBTRACT"
+
+
+{-| The `BlendMode` type allows you to define which blend mode to use.
+-}
+type BlendMode
+  = Add
+  | Subtract
+  | ReverseSubtract
+
+
+computeCompareModeString : CompareMode -> String
+computeCompareModeString mode =
+  case mode of
+    Never ->
+      "NEVER"
+
+    Always ->
+      "ALWAYS"
+
+    Less ->
+      "LESS"
+
+    LessOrEqual ->
+      "LEQUAL"
+
+    Equal ->
+      "EQUAL"
+
+    GreaterOrEqual ->
+      "GEQUAL"
+
+    Greater ->
+      "Greater"
+
+    NotEqual ->
+      "NOTEQUAL"
+
+
+{-| The `CompareMode` type allows you to define how to compare values.
+-}
+type CompareMode
+  = Never
+  | Always
+  | Less
+  | LessOrEqual
+  | Equal
+  | GreaterOrEqual
+  | Greater
+  | NotEqual
+
+
+computeFaceModeString : FaceMode -> String
+computeFaceModeString mode =
+  case mode of
+    Front ->
+      "FRONT"
+
+    Back ->
+      "BACK"
+
+    FrontAndBack ->
+      "FRONT_AND_BACK"
+
+
+{-| The `FaceMode` type defines which face of the stencil state is updated.
+-}
+type FaceMode
+  = Front
+  | Back
+  | FrontAndBack
+
+
+computeZModeString : ZMode -> String
+computeZModeString mode =
+  case mode of
+    Keep ->
+      "KEEP"
+
+    None ->
+      "ZERO"
+
+    Replace ->
+      "REPLACE"
+
+    Increment ->
+      "INCREMENT"
+
+    Decrement ->
+      "DECREMENT"
+
+    Invert ->
+      "INVERT"
+
+    IncrementWrap ->
+      "INCREMENT_WRAP"
+
+    DecrementWrap ->
+      "DECREMENT_WRAP"
+
+
+{-| The `ZMode` type allows you to define what to do with the stencil buffer value.
+
++ `Keep`: Keeps the current value.
++ `None`: Sets the stencil buffer value to 0.
++ `Replace`: Sets the stencil buffer value to `ref`,
+See `StencilFunc` for more information.
++ `Increment`: Increments the current stencil buffer value.
+Clamps to the maximum representable unsigned value.
++ `Decrement`: Decrements the current stencil buffer value. Clamps to 0.
++ `Invert`: Bitwise inverts the current stencil buffer value.
++ `IncrementWrap`: Increments the current stencil buffer value.
+Wraps stencil buffer value to zero when incrementing
+the maximum representable unsigned value.
++ `DecrementWrap`: Decrements the current stencil buffer value.
+Wraps stencil buffer value to the maximum representable unsigned
+value when decrementing a stencil buffer value of zero.
+-}
+type ZMode
+  = Keep
+  | None
+  | Replace
+  | Increment
+  | Decrement
+  | Invert
+  | IncrementWrap
+  | DecrementWrap


### PR DESCRIPTION
Bringing support for all pre-fragment operations and some special functions.
This does break the API (`webgl` function).

#### References

The main reference has been the khornos manual pages and [the WebGL API 1.0 reference cheat sheet](https://www.khronos.org/files/webgl/webgl-reference-card-1_0.pdf).

#### Description

This update allows users to enable/disable the capabilities they want and use the pre-fragmented operations available. This also removes the default call to enable DepthTests, as this should be defined by the user if she wants it.

#### Background

First I wanted to go really minimalistic to give all the freedom the user wants. But this was quit error prone, non-type safe and gives no protection at all at compile time. Therefore I decided to go for what you can find in this pull request. It does expand the code quite a bit. However it allows for a well specified and type-safe way to use these functions.

Hopefully we find an agreement on this so that me and others can start this functionality in our projects that depend on this great library. Also as I didn't do so yet, thank you for all the work that has been put in this library so far, as it really makes using WebGL fun and surprisngly easy.

####  Example webgl call

```elm
import WebGL as GL

{-| ... -}

GL.webgl (w, h)
  [ GL.Enable GL.Blend
  , GL.Disable GL.DepthTest
  , GL.BlendEquation GL.Add
  , GL.BlendFunc (GL.SrcAlpha, GL.OneMinusSrcAlpha)
  ]
  [ GL.entity vertexShader fragmentShader mesh { mat = matrix } ]
```